### PR TITLE
Update schema.py for pydantic schema gen error

### DIFF
--- a/apps/dashboard/schema.py
+++ b/apps/dashboard/schema.py
@@ -2,11 +2,13 @@ from typing import Optional
 from django.utils import timezone
 from ninja import ModelSchema
 from .models import Todo
+from datetime import datetime
+
 
 
 class TodoSchema(ModelSchema):
 
-    created: Optional = timezone.now()
+    created: Optional[datetime] = timezone.now()
     status: Optional[str] = "outstanding"
 
     class Config:


### PR DESCRIPTION
This will eliminate the below error
pydantic.errors.PydanticSchemaGenerationError: Unable to generate pydantic-core schema for typing.Optional.